### PR TITLE
Remove zsh from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install dependencies (Linux)
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install zsh
-      - name: Install dependencies (macOS)
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew update
-          brew install zsh
       - name: Install Haskell tooling
         uses: haskell/actions/setup@v2
         with:


### PR DESCRIPTION
It looks like `zsh` is not a required dependency in the context of this project