### PR TITLE
Export a couple of types, update Haddock

### DIFF
--- a/src/Time/SCalendar/Operations.hs
+++ b/src/Time/SCalendar/Operations.hs
@@ -27,7 +27,7 @@ import qualified Data.Set as S ( null
 
 -- | Given an SCalendar of size 2^n, this function increases its size k times, that is,
 -- 2^(n+k). The new SCalendar is properly updated up to its root so that it will render
--- the same results as the previous one. For example, given an SCalendar `c` of size 2^5=32,
+-- the same results as the previous one. For example, given an SCalendar @c@ of size 2^5=32,
 -- 'augmentCalendar c 3' would produce a new SCalendar of size 2^(5+3)=256.
 augmentCalendar :: SCalendar -- ^ SCalendar to be augmented.
                 -> Int -- ^ Number of times by which the SCalendar will be augmented.

--- a/src/Time/SCalendar/Types.hs
+++ b/src/Time/SCalendar/Types.hs
@@ -40,7 +40,7 @@ data TimePeriod =
                      -- a specific day of the calendar.
   deriving (Eq, Show)
 
--- | Check if a time-period `t1` is included in a time-period `t2`. Note that neither a
+-- | Check if a time-period @t1@ is included in a time-period @t2@. Note that neither a
 -- TimeUnit can be included in another TimeUnit nor a TimeInterval can be included
 -- in a TimeUnit. If two TimeIntervals are equal they are said to be included in
 -- one another.
@@ -99,7 +99,7 @@ data Report = Report
 -- of time covered by them. TimeUnits are only encountered in the leaves since they represent
 -- specific days, or time units, of the Calendar. The unit of time of this Calendar library is a nominal
 -- day (or 86400 seconds). Each node of a Calendar also carries additional data according to the
--- "top-nodes" algorithm: a `Q` set and a `QN` set. For more information about the meaning of these
+-- "top-nodes" algorithm: a @Q@ set and a @QN@ set. For more information about the meaning of these
 -- sets visit: <https://en.wikipedia.org/wiki/Top-nodes_algorithm>
 data Calendar =
     Unit TimePeriod (Set Text) (Set Text)

--- a/src/Time/SCalendar/Zippers.hs
+++ b/src/Time/SCalendar/Zippers.hs
@@ -1,5 +1,7 @@
 module Time.SCalendar.Zippers
-  ( CalendarZipper
+  ( Breadcrumbs
+  , CalendarZipper
+  , Crumb
   , goUp
   , goLeft
   , goRight


### PR DESCRIPTION
This PR removes a couple of false links that were in the Haddock, and also exports the `Breadcrumbs` and `Crumb` in the `Time.SCalendar.Zippers` module. These were being linked in the definition of `CalendarZipper`, but Haddock couldn't link to them because they were not exported.

After this PR gets merged, I will update the package on Hackage and release a new minor version 1.2.1 (there are no breaking changes).

Solves #22.