### PR TITLE
Remove GHC 7.10.3 support for `ubuntu-latest` in CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ jobs:
         ghc:
           - "9.0"
           - "8.10"
-          - "7.10.3"
-
+        include:
+          - os: macos-latest
+            ghc: "7.10.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
As mentioned in the [version support](https://github.com/haskell/actions/tree/main/setup#version-support) section of the `haskell/actions/setup` GH Action, GHC 7.10.3 is not supported on `ubuntu-22.04` or up. We still want to have some build support for GHC 7.10.3 since this library was built including compatibility with that version and we still haven't introduced any changes that break that compatibility. This PR removes GHC 7.10.3 from the CI matrix, but adds an extra job that runs `macos-latest` with GHC 7.10.3.