### PR TITLE
Remove GHC 7.10.3 from CI build matrix and remove build badge from README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
         ghc:
           - "9.0"
           - "8.10"
-          - "7.10.3"
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build](https://github.com/stackbuilders/scalendar/actions/workflows/build.yml/badge.svg)](https://github.com/stackbuilders/scalendar/actions/workflows/build.yml)
 [![Hackage version](https://img.shields.io/hackage/v/scalendar.svg)](https://hackage.haskell.org/package/scalendar-1.2.0)
 [![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
 


### PR DESCRIPTION
Relates to #24. GHC 7.10.3 kept failing in the CI since the [setup-haskell](https://github.com/actions/setup-haskell) action does not support that version anymore for `ubuntu-latest`.This PR removes that version from the matrix.

Also, since we have deprecated the repository, I don't think it makes too much sense to have a build badge in the README. This PR removes it.